### PR TITLE
 Fix header logo text position

### DIFF
--- a/css/airspace.css
+++ b/css/airspace.css
@@ -72,9 +72,6 @@ header .navbar {
   margin-bottom: 0px;
   border: 0px;
 }
-header .navbar-brand {
-  padding: 0;
-}
 header .navbar-brand img
 {
   max-width: 100%;


### PR DESCRIPTION
ヘッダーのロゴテキストの位置を調整しました。

修正前
<img width="1440" alt="スクリーンショット 2019-06-14 1 17 45" src="https://user-images.githubusercontent.com/8760841/59450727-d2f98900-8e44-11e9-8f09-57be719211d5.png">

修正後
<img width="1440" alt="スクリーンショット 2019-06-14 1 28 37" src="https://user-images.githubusercontent.com/8760841/59450748-e278d200-8e44-11e9-80c1-4793915c86db.png">
