### PR TITLE
fix header logo text position check with mobile and slim browser

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,12 +9,13 @@
 <link rel="stylesheet" href="{{ site.baseurl }}/css/owl.carousel.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/bootstrap.min.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/font-awesome.min.css" />
-<link rel="stylesheet" href="{{ site.baseurl }}/css/custom.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/ionicons.min.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/animate.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/responsive.css" />
 <link rel="stylesheet" href="{{ site.baseurl }}/css/syntax.css" />
+<link rel="stylesheet" href="{{ site.baseurl }}/css/custom.css" />
+
 
 <!-- Js -->
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>

--- a/css/custom.css
+++ b/css/custom.css
@@ -841,8 +841,6 @@ footer .footer-manu ul li a:hover {
   .navbar-brand {
     padding: 0 15px;
     width: 80%;
-    line-height: 3rem!important;
+    line-height: 3rem;
   }
 }
-
-

--- a/css/custom.css
+++ b/css/custom.css
@@ -72,9 +72,6 @@ header .navbar {
   margin-bottom: 0px;
   border: 0px;
 }
-header .navbar-brand {
-  padding: 0;
-}
 header .navbar-brand img
 {
   max-width: 100%;
@@ -839,3 +836,13 @@ footer .footer-manu ul li a:hover {
 {
   padding: 0;
 }
+
+@media only screen and (max-width: 767px) {
+  .navbar-brand {
+    padding: 0 15px;
+    width: 80%;
+    line-height: 3rem!important;
+  }
+}
+
+


### PR DESCRIPTION
CSSを再調整しました。

### iPhone5/SE
![スクリーンショット 2019-07-01 19 05 16](https://user-images.githubusercontent.com/8760841/60428253-68618f00-9c33-11e9-8341-84c949cefe72.png)

###  iPhone6/7/8 +
![スクリーンショット 2019-07-01 19 05 28](https://user-images.githubusercontent.com/8760841/60428273-70b9ca00-9c33-11e9-9f20-a85236e3e6e7.png)

### iPad
![スクリーンショット 2019-07-01 19 05 00](https://user-images.githubusercontent.com/8760841/60428278-757e7e00-9c33-11e9-8a22-5863259649fc.png)

### width 767px（ブラウザ）
![スクリーンショット 2019-07-01 19 06 33](https://user-images.githubusercontent.com/8760841/60428286-78796e80-9c33-11e9-860a-accaccf21471.png)





